### PR TITLE
refactor: goat foundation

### DIFF
--- a/contracts/bridge/Bridge.sol
+++ b/contracts/bridge/Bridge.sol
@@ -5,6 +5,7 @@ import {Burner} from "../library/utils/Burner.sol";
 import {BitcoinAddress} from "../library/codec/address.sol";
 import {BaseAccess} from "../library/utils/BaseAccess.sol";
 import {PreDeployedAddresses} from "../library/constants/Predeployed.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {IBridge} from "../interfaces/bridge/Bridge.sol";
 import {IBridgeParam} from "../interfaces/bridge/BridgeParam.sol";
@@ -12,7 +13,7 @@ import {IBridgeParam} from "../interfaces/bridge/BridgeParam.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-contract Bridge is BaseAccess, IBridge, IBridgeParam, IERC165 {
+contract Bridge is Ownable, BaseAccess, IBridge, IBridgeParam, IERC165 {
     using Address for address payable;
     using BitcoinAddress for bytes;
 
@@ -35,7 +36,7 @@ contract Bridge is BaseAccess, IBridge, IBridgeParam, IERC165 {
     uint256 internal constant maxBasePoints = 1e4;
 
     // It is only for testing
-    constructor() {
+    constructor(address owner) Ownable(owner) {
         param = Param({
             rateLimit: 300,
             depositTaxBP: 0,
@@ -285,7 +286,7 @@ contract Bridge is BaseAccess, IBridge, IBridgeParam, IERC165 {
     function setDepositTax(
         uint16 _bp,
         uint64 _max
-    ) external override OnlyGoatFoundation {
+    ) external override onlyOwner {
         if (_bp > maxBasePoints) {
             revert TaxTooHigh();
         }
@@ -306,7 +307,7 @@ contract Bridge is BaseAccess, IBridge, IBridgeParam, IERC165 {
     function setWithdrawalTax(
         uint16 _bp,
         uint64 _max
-    ) external override OnlyGoatFoundation {
+    ) external override onlyOwner {
         if (_bp > maxBasePoints) {
             revert TaxTooHigh();
         }
@@ -324,7 +325,7 @@ contract Bridge is BaseAccess, IBridge, IBridgeParam, IERC165 {
         emit WithdrawalTaxUpdated(_bp, _max);
     }
 
-    function setRateLimit(uint16 _sec) external override OnlyGoatFoundation {
+    function setRateLimit(uint16 _sec) external override onlyOwner {
         require(_sec > 0, "invalid throttle setting");
         param.rateLimit = _sec;
         emit RateLimitUpdated(_sec);

--- a/contracts/goat/GoatFoundation.sol
+++ b/contracts/goat/GoatFoundation.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.24;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {PreDeployedAddresses} from "../library/constants/Predeployed.sol";
-
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
@@ -11,7 +9,6 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import {IGoatFoundation} from "../interfaces/GoatFoundation.sol";
-import {IBridgeParam} from "../interfaces/bridge/BridgeParam.sol";
 
 contract GoatFoundation is Ownable, IERC165, IGoatFoundation {
     using SafeERC20 for IERC20;

--- a/contracts/goat/GoatFoundation.sol
+++ b/contracts/goat/GoatFoundation.sol
@@ -17,41 +17,42 @@ contract GoatFoundation is Ownable, IERC165, IGoatFoundation {
     using SafeERC20 for IERC20;
     using Address for address payable;
 
-    // It's for testing only
-    // the owner can be DAO or a Safe wallet
     constructor(address owner) Ownable(owner) {}
 
     function transfer(
-        address payable _to,
-        uint256 _amount
+        address payable to,
+        uint256 amount
     ) external override onlyOwner {
-        _to.sendValue(_amount);
-        emit Transfer(_to, _amount);
+        to.sendValue(amount);
+        emit Transfer(to, amount);
     }
 
     function transferERC20(
-        address _token,
-        address _to,
-        uint256 _amount
+        address token,
+        address to,
+        uint256 amount
     ) external override onlyOwner {
-        IERC20(_token).safeTransfer(_to, _amount);
+        IERC20(token).safeTransfer(to, amount);
+    }
+
+    /**
+     * invoke calls a contract
+     * @param target a contract address but not the owner, otherwise revert
+     * @param data contract call data
+     * @param value contract call with value, owner can grant the value
+     */
+    function invoke(
+        address payable target,
+        bytes calldata data,
+        uint256 value
+    ) external payable onlyOwner returns (bytes memory) {
+        require(target != owner(), "!owner"); // ensures reentrant is impossible
+        return target.functionCallWithValue(data, value);
     }
 
     // donation
     receive() external payable {
         emit Donate(msg.sender, msg.value);
-    }
-
-    function setDepositTax(uint16 _bp, uint64 _max) external onlyOwner {
-        IBridgeParam(PreDeployedAddresses.Bridge).setDepositTax(_bp, _max);
-    }
-
-    function setWithdrawalTax(uint16 _bp, uint64 _max) external onlyOwner {
-        IBridgeParam(PreDeployedAddresses.Bridge).setWithdrawalTax(_bp, _max);
-    }
-
-    function setRateLimit(uint16 _sec) external onlyOwner {
-        IBridgeParam(PreDeployedAddresses.Bridge).setRateLimit(_sec);
     }
 
     function supportsInterface(

--- a/contracts/interfaces/GoatFoundation.sol
+++ b/contracts/interfaces/GoatFoundation.sol
@@ -8,4 +8,10 @@ interface IGoatFoundation {
     function transfer(address payable, uint256) external;
 
     function transferERC20(address token, address to, uint256 amount) external;
+
+    function invoke(
+        address payable target,
+        bytes calldata data,
+        uint256 value
+    ) external payable returns (bytes memory);
 }

--- a/contracts/library/utils/BaseAccess.sol
+++ b/contracts/library/utils/BaseAccess.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.24;
 
 import {Executor} from "../constants/Executor.sol";
-import {PreDeployedAddresses} from "../constants/Predeployed.sol";
-import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract BaseAccess {
     error AccessDenied();

--- a/contracts/library/utils/BaseAccess.sol
+++ b/contracts/library/utils/BaseAccess.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import {Executor} from "../constants/Executor.sol";
 import {PreDeployedAddresses} from "../constants/Predeployed.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 contract BaseAccess {
     error AccessDenied();
@@ -10,13 +11,6 @@ contract BaseAccess {
 
     modifier OnlyRelayer() {
         if (msg.sender != Executor.Relayer) {
-            revert AccessDenied();
-        }
-        _;
-    }
-
-    modifier OnlyGoatFoundation() {
-        if (msg.sender != PreDeployedAddresses.GoatFoundation) {
             revert AccessDenied();
         }
         _;

--- a/contracts/test/Token.sol
+++ b/contracts/test/Token.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract TestToken is ERC20, Ownable {
+    uint256 public num;
+
+    constructor() ERC20("Test Stub", "TEST") Ownable(msg.sender) {}
+
+    function mint(address _target, uint256 _amount) public onlyOwner {
+        _mint(_target, _amount);
+    }
+
+    function setNumber(uint256 _n) public payable {
+        num = _n;
+    }
+}

--- a/ignition/modules/Genesis.ts
+++ b/ignition/modules/Genesis.ts
@@ -13,7 +13,9 @@ export default buildModule("Genesis", (m) => {
   ]);
 
   const wgbtc = m.contract("WrappedGoatBitcoin");
-  const bridge = m.contract("Bridge");
+  const bridge = m.contract("Bridge", [
+    m.getParameter("bridge.owner"),
+  ]);
 
   const relayer = m.contract("Relayer", [
     m.getParameter("relayer.owner"),

--- a/test/Bridge.ts
+++ b/test/Bridge.ts
@@ -93,12 +93,10 @@ describe("Bridge", async () => {
         tax: 10n,
       };
 
-      const { bridge, owner, relayer } =
-        await loadFixture(fixture);
+      const { bridge, owner, relayer } = await loadFixture(fixture);
 
       await setNextBlockBaseFeePerGas(0);
-      await bridge
-        .setDepositTax(1, 10, { gasPrice: 0 });
+      await bridge.setDepositTax(1, 10, { gasPrice: 0 });
 
       expect(
         await bridge.isDeposited(tx2.id, tx2.txout),
@@ -127,8 +125,7 @@ describe("Bridge", async () => {
       const { bridge } = await loadFixture(fixture);
 
       await setNextBlockBaseFeePerGas(0);
-      await bridge
-        .setWithdrawalTax(0, 0, { gasPrice: 0 });
+      await bridge.setWithdrawalTax(0, 0, { gasPrice: 0 });
 
       const amount = BigInt(1e10);
       const txPrice = 1n;
@@ -237,8 +234,7 @@ describe("Bridge", async () => {
       const { bridge, owner } = await loadFixture(fixture);
 
       await setNextBlockBaseFeePerGas(0);
-      await bridge
-        .setWithdrawalTax(0, 0, { gasPrice: 0 });
+      await bridge.setWithdrawalTax(0, 0, { gasPrice: 0 });
 
       const amount = BigInt(1e18);
       const txPrice = 1n;
@@ -260,8 +256,7 @@ describe("Bridge", async () => {
       const { bridge, owner } = await loadFixture(fixture);
 
       await setNextBlockBaseFeePerGas(0);
-      await bridge
-        .setWithdrawalTax(0, 0, { gasPrice: 0 });
+      await bridge.setWithdrawalTax(0, 0, { gasPrice: 0 });
 
       const dust = 100n;
       const amount = BigInt(1e18) + dust;

--- a/test/GoatFoundation.ts
+++ b/test/GoatFoundation.ts
@@ -25,14 +25,10 @@ describe("GoatFoundation", async () => {
 
     it("transfer", async () => {
         const { owner, goatfdn, others } = await loadFixture(fixture);
-        expect(
-            await owner.sendTransaction({
-                to: await goatfdn.getAddress(),
-                value: ethers.parseEther("10"),
-            }),
-        )
+        const grant = ethers.parseEther("10")
+        expect(await owner.sendTransaction({ to: goatfdn, value: grant }))
             .emit(goatfdn, "Donate")
-            .withArgs(owner.address, ethers.parseEther("10"));
+            .withArgs(owner, grant);
 
         const amount = 1n;
         await expect(
@@ -47,9 +43,9 @@ describe("GoatFoundation", async () => {
     it("transfer token", async () => {
         const { goatfdn, others, testToken } = await loadFixture(fixture);
 
-        await testToken.mint(goatfdn, ethers.parseEther("10"));
-
         const amount = 1n;
+        await testToken.mint(goatfdn, amount);
+
         await expect(
             goatfdn.connect(others[0]).transferERC20(testToken, receiver, amount),
         ).revertedWithCustomError(goatfdn, "OwnableUnauthorizedAccount");
@@ -82,12 +78,9 @@ describe("GoatFoundation", async () => {
 
         await goatfdn.invoke(testToken, calldata, amount, { value: amount });
 
-        await owner.sendTransaction({
-            to: await goatfdn.getAddress(),
-            value: amount,
-        });
-
+        await owner.sendTransaction({ to: goatfdn, value: amount });
         await goatfdn.invoke(testToken, calldata, amount);
+
         expect(await testToken.num()).eq(number);
 
         expect(await ethers.provider.getBalance(goatfdn)).eq(0n);

--- a/test/GoatFoundation.ts
+++ b/test/GoatFoundation.ts
@@ -1,0 +1,85 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { Executors } from "./constant";
+
+describe("GoatFoundation", async () => {
+    const receiver = "0xdeadbeafdeadbeafdeadbeafdeadbeafdeadbeaf"
+
+    async function fixture() {
+        const [owner, ...others] = await ethers.getSigners();
+        const factory = await ethers.getContractFactory("GoatFoundation");
+        const goatfdn = await factory.deploy(owner);
+
+        const tokenFactory = await ethers.getContractFactory("TestToken")
+        const testToken = await tokenFactory.deploy()
+
+        await ethers.getContractFactory("GoatToken")
+        return {
+            owner,
+            others,
+            goatfdn,
+            testToken,
+        };
+    }
+
+    it("transfer", async () => {
+        const { owner, goatfdn, others } = await loadFixture(fixture)
+        expect(await owner.sendTransaction({
+            to: await goatfdn.getAddress(),
+            value: ethers.parseEther("10"),
+        })).emit(goatfdn, "Donate").withArgs(owner.address, ethers.parseEther("10"))
+
+        const amount = 1n
+        await expect(goatfdn.connect(others[0]).transfer(others[0], amount))
+            .revertedWithCustomError(goatfdn, "OwnableUnauthorizedAccount")
+        expect(await goatfdn.transfer(receiver, amount)).emit(goatfdn, "Transfer").withArgs(receiver, amount)
+        expect(await ethers.provider.getBalance(receiver)).eq(amount)
+    })
+
+    it("transfer token", async () => {
+        const { goatfdn, others, testToken } = await loadFixture(fixture)
+
+        await testToken.mint(goatfdn, ethers.parseEther("10"))
+
+        const amount = 1n
+        await expect(goatfdn.connect(others[0]).transferERC20(testToken, receiver, amount))
+            .revertedWithCustomError(goatfdn, "OwnableUnauthorizedAccount")
+
+        expect(await goatfdn.transferERC20(testToken, receiver, amount))
+            .emit(testToken, "Transfer").withArgs(goatfdn, receiver, amount)
+        expect(await testToken.balanceOf(receiver)).eq(amount)
+    })
+
+    it("invoke", async () => {
+        const { owner, goatfdn, others, testToken } = await loadFixture(fixture)
+
+        const number = 100n
+        const calldata = testToken.interface.encodeFunctionData("setNumber", [number])
+
+        await expect(goatfdn.invoke(owner, calldata, 0)).revertedWith("!owner")
+
+        await expect(goatfdn.connect(others[0]).invoke(testToken, calldata, 0))
+            .revertedWithCustomError(goatfdn, "OwnableUnauthorizedAccount")
+
+        await expect(goatfdn.invoke(others[0], calldata, 0))
+            .revertedWithCustomError(goatfdn, "AddressEmptyCode").withArgs(others[0])
+
+        const amount = 1n
+
+
+
+        await goatfdn.invoke(testToken, calldata, amount, { value: amount })
+
+        await owner.sendTransaction({
+            to: await goatfdn.getAddress(),
+            value: amount,
+        })
+
+        await goatfdn.invoke(testToken, calldata, amount)
+        expect(await testToken.num()).eq(number)
+
+        expect(await ethers.provider.getBalance(goatfdn)).eq(0n)
+        expect(await ethers.provider.getBalance(testToken)).eq(amount * 2n)
+    })
+})


### PR DESCRIPTION
- Remove OnlyGoatFoundation, so we can transfer the ownership to DAO then
- Add invoke() to GoatFoundation, which allows owner to call any contracts include bridge contract