### PR TITLE
feat(bridge): save gas

### DIFF
--- a/contracts/bridge/Bridge.sol
+++ b/contracts/bridge/Bridge.sol
@@ -21,9 +21,6 @@ contract Bridge is Ownable, BaseAccess, IBridge, IBridgeParam, IERC165 {
 
     Withdrawal[] public withdrawals;
 
-    // the withdrawal receipts
-    mapping(uint256 id => Receipt receipt) public receipts;
-
     // 1 satoshi = 10 gwei
     uint256 internal constant SATOSHI = 10 gwei;
 
@@ -140,7 +137,6 @@ contract Bridge is Ownable, BaseAccess, IBridge, IBridgeParam, IERC165 {
                 tax: tax,
                 maxTxPrice: _maxTxPrice,
                 updatedAt: block.timestamp,
-                receiver: _receiver,
                 status: WithdrawalStatus.Pending
             })
         );
@@ -271,7 +267,6 @@ contract Bridge is Ownable, BaseAccess, IBridge, IBridgeParam, IERC165 {
                 status == WithdrawalStatus.Canceling
         );
 
-        receipts[_wid] = Receipt(_txid, _txout, _received);
         withdrawal.status = WithdrawalStatus.Paid;
         withdrawal.updatedAt = block.timestamp;
 

--- a/contracts/interfaces/bridge/Bridge.sol
+++ b/contracts/interfaces/bridge/Bridge.sol
@@ -43,19 +43,11 @@ interface IBridge {
 
     struct Withdrawal {
         address sender;
+        uint16 maxTxPrice;
+        WithdrawalStatus status;
         uint256 amount; // msg.value - tax
         uint256 tax; // tax for goat foundation
-        uint16 maxTxPrice;
         uint256 updatedAt;
-        string receiver;
-        WithdrawalStatus status;
-    }
-
-    // the payment receipt
-    struct Receipt {
-        bytes32 txid;
-        uint32 txout;
-        uint256 received;
     }
 
     function isDeposited(

--- a/test/Bridge.ts
+++ b/test/Bridge.ts
@@ -174,7 +174,6 @@ describe("Bridge", async () => {
         expect(withdrawal.tax).eq(tax);
         expect(withdrawal.maxTxPrice).eq(txPrice);
         expect(withdrawal.updatedAt).eq(await timeHelper.latest());
-        expect(withdrawal.receiver).eq(addr1);
         expect(withdrawal.status).eq(1);
         expect(withdrawal.amount + withdrawal.tax, "actual + tax = amount").eq(
           amount,
@@ -217,12 +216,6 @@ describe("Bridge", async () => {
         expect(withdrawal.updatedAt).eq(await timeHelper.latest());
         expect(withdrawal.status).eq(5);
 
-        const receipt = await bridge.receipts(wid);
-
-        expect(receipt.txid).eq(txid);
-        expect(receipt.txout).eq(txout);
-        expect(receipt.received).eq(paid);
-
         expect(
           await ethers.provider.getBalance(await bridge.getAddress()),
           "bridge balance",
@@ -253,7 +246,6 @@ describe("Bridge", async () => {
       expect(withdrawal.tax).eq(0n);
       expect(withdrawal.maxTxPrice).eq(txPrice);
       expect(withdrawal.updatedAt).eq(await timeHelper.latest());
-      expect(withdrawal.receiver).eq(addr1);
       expect(withdrawal.status).eq(1);
     });
 
@@ -276,7 +268,6 @@ describe("Bridge", async () => {
       expect(withdrawal.tax).eq(dust);
       expect(withdrawal.maxTxPrice).eq(txPrice);
       expect(withdrawal.updatedAt).eq(await timeHelper.latest());
-      expect(withdrawal.receiver).eq(addr1);
       expect(withdrawal.status).eq(1);
     });
 


### PR DESCRIPTION
1. remove Receipt since we already have it in the consensus layer, and it can be processed with subgraph
2. adjust fields order of Withdrawal to save slot spaces
3. remove receiver address field of Withdrawal